### PR TITLE
Add a note about sendPoweredByHeader

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -66,6 +66,8 @@ return [
         // Enable CSRF Protection (recommended)
         'enableCsrfProtection' => true,
         'csrfTokenName' => 'APP_CSRF_TOKEN',
+        // Some hosting environments may use the sendPoweredByHeader to route requests accordingly
+        // Check before disabling, to not negate performance in production
         'sendPoweredByHeader' => false,
         'phpSessionName' => 'SessionId',
 


### PR DESCRIPTION
Hello Kind team!

Something to be aware of with the `sendPoweredByHeader` if you're not already aware. 

Depending on the hosting environment, the `X-Powered-By` being part of the request is actually beneficial in some situations. In the case of Fort Rabbit their environment seeks it out and use it to determine if the request is for a Craft based site/app. They recommend having it in the request so their environment can see it, but Fort Rabbit ultimately strip it and remove it for the final served request.

Having it removed entirely can actually affect performance. I had a conversation with Oliver from Fort Rabbit and they advise not removing it this way, given they do it for all apps anyway.

I think the general security guidelines from Craft to recommend setting it to `false` in production, but in some cases it can actually have a negative impact here.

Hope this helps!