### PR TITLE
Remove environment config var, not required in Craft 3

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -47,7 +47,6 @@ return [
         'devMode' => filter_var(getenv('CRAFT_DEBUG'), FILTER_VALIDATE_BOOLEAN),
 
         'testToEmailAddress' => getenv('CRAFT_CATCH_ALL_EMAIL_ADDRESS') ?: null,
-        'environment' => getenv('ENVIRONMENT'),
         /**
          * Caching
          */


### PR DESCRIPTION
In Craft 3 you don't need to have an environment config key defined in config if you already use the default ENVIRONMENT env var. It can be accessed through the following methods.

```php
Craft::$app->config->env
```

```twig
{{ getenv('ENVIRONMENT') }}
{{ craft.app.config.env }}
```