### PR TITLE
Sticky footer with improved semantics

### DIFF
--- a/templates/_includes/chrome/footer.twig
+++ b/templates/_includes/chrome/footer.twig
@@ -1,3 +1,3 @@
-<footer>
-    &copy; {{ now | date('Y') }} {{ siteName }}
+<footer class="mt-auto">
+  <small>&copy; {{ now | date('Y') }} {{ siteName }}</small>
 </footer>

--- a/templates/_layouts/application.twig
+++ b/templates/_layouts/application.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en" class="min-h-full no-js">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -49,7 +49,7 @@
   </script>
 </head>
 
-<body class="{{ craft.app.config.general.devMode ? 'debug'}}">
+<body class="min-h-screen flex flex-col {{ craft.app.config.general.devMode ? 'debug'}}">
   {% block fullPage %}
     {% block masthead %}
       {% include '_includes/chrome/masthead' %}


### PR DESCRIPTION
Ensures the footer remains at the bottom of the page, even on short pages, and improves the semantics of the copyright notice.