### PR TITLE
[Improved] template debug info in dev

### DIFF
--- a/templates/_layouts/application.twig
+++ b/templates/_layouts/application.twig
@@ -49,7 +49,7 @@
   </script>
 </head>
 
-<body class="{{ craft.app.config.general.devMode ? 'debug'}}">
+<body class="{% if craft.app.config.general.devMode %} entryId-{{ entry is defined and entry ? entry.id : '' }} sectionId-{{ section is defined and section ? section.id : '' }} layout-{{ entry is defined and entry ? entry.type.handle : '' }}{% endif %}">
   {% block fullPage %}
     {% block masthead %}
       {% include '_includes/chrome/masthead' %}


### PR DESCRIPTION
Adds debug info on entry, section and layout to the body element to aid template debugging in dev mode.